### PR TITLE
Fix paths-ignore quotes in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [ main ]
     paths-ignore:
-      - docs/**
-      - specs/**
-      - *.example
-      - *.md
-      - .dockerignore
-      - .gitignore
-      - .modified
-      - .devcontainer/**
-      - .github/**
+      - 'docs/**'
+      - 'specs/**'
+      - '*.example'
+      - '*.md'
+      - '.dockerignore'
+      - '.gitignore'
+      - '.modified'
+      - '.devcontainer/**'
+      - '.github/**'
       
 permissions:
   contents: read


### PR DESCRIPTION
Updated paths-ignore syntax to use single quotes.